### PR TITLE
Add PHPUnit as a dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,14 @@ matrix:
   allow_failures:
     - php: nightly
 
-before_install:
-  - composer global config repositories.bin path $PWD
-  - composer global require bamarni/composer-bin-plugin:dev-master
-
 install:
   - composer install
+  - composer global require "bamarni/composer-bin-plugin:dev-master"
+  - composer global bin phpunit require phpunit/phpunit
 
 script:
   - vendor/bin/phpunit
+  - $HOME/.composer/vendor-bin/phpunit/vendor/phpunit/phpunit/phpunit
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
   - 'nightly'
 
 matrix:
@@ -19,6 +20,9 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest'
   allow_failures:
     - php: nightly
+
+before_install:
+  - composer global config repositories.bin path $PWD
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,15 @@
     },
     "require-dev": {
         "composer/composer": "dev-master",
+        "phpunit/phpunit": "^4.6||^5.0",
         "symfony/console": "^2.5 || ^3.0"
     },
     "scripts": {
         "post-install-cmd": ["@composer bin phpunit install"],
         "post-update-cmd": ["@post-install-cmd"]
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "class": "Bamarni\\Composer\\Bin\\Plugin",

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,6 @@
         "phpunit/phpunit": "^4.6||^5.0",
         "symfony/console": "^2.5 || ^3.0"
     },
-    "scripts": {
-        "post-install-cmd": ["@composer bin phpunit install"],
-        "post-update-cmd": ["@post-install-cmd"]
-    },
     "config": {
         "sort-packages": true
     },

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,5 +1,0 @@
-{
-    "require": {
-        "phpunit/phpunit": "^4.8||^5.0"
-    }
-}


### PR DESCRIPTION
PHPUnit was installed only as a transient dependency but as it is used for tests, it should be a dev dependency instead.
