### PR TITLE
First stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "extra": {
         "class": "Bamarni\\Composer\\Bin\\Plugin",
         "branch-alias": {
-            "dev-master": "0.0.x-dev"
+            "dev-master": "1.0.0-dev"
         }
     }
 }


### PR DESCRIPTION
This allows you to do `composer require --dev bamarni/composer-bin-plugin:^1.0.0@dev` instead of `composer require --dev bamarni/composer-bin-plugin:^0.0.1@dev` or `composer require --dev bamarni/composer-bin-plugin:dev-master`.