### PR TITLE
Set working-dir parameter to prevent composer from prompting the user to use the root composer.json file

### DIFF
--- a/src/BinCommand.php
+++ b/src/BinCommand.php
@@ -101,6 +101,7 @@ class BinCommand extends BaseCommand
         }
 
         $this->chdir($namespace);
+        $input = new StringInput((string) $input . ' --working-dir=.');
 
         return $application->doRun($input, $output);
     }


### PR DESCRIPTION
Please see the issue #30 for information. 
Turns out, there is no way to turn off composer from suggesting the user to use the root level `composer.json`. I submitted a PR composer/composer#6651, but I'm not sure if it will go through. If it does, here is a PR for this plugin to set the `--working-dir` option, so composer does not suggest the user to use the root level `composer.json` file. 