### PR TITLE
Allow Symfony v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "composer/composer": "dev-master",
-        "symfony/console": "^2.5 || ^3.0"
+        "symfony/console": "^2.5 || ^3.0 || ^4.0"
     },
     "scripts": {
         "post-install-cmd": ["@composer bin phpunit install"],


### PR DESCRIPTION
Just adding the ability to use `symfony/console` v4.0.