### PR TITLE
Make sure that composer file exists before running

### DIFF
--- a/src/BinCommand.php
+++ b/src/BinCommand.php
@@ -102,7 +102,8 @@ class BinCommand extends BaseCommand
         }
 
         $this->chdir($namespace);
-        
+
+        // some plugins require access to composer file e.g. Symfony Flex
         if (!file_exists(Factory::getComposerFile())) {
             file_put_contents(Factory::getComposerFile(), '{}');
         }

--- a/src/BinCommand.php
+++ b/src/BinCommand.php
@@ -102,6 +102,11 @@ class BinCommand extends BaseCommand
         }
 
         $this->chdir($namespace);
+        
+        if (!file_exists(Factory::getComposerFile())) {
+            file_put_contents(Factory::getComposerFile(), '{}');
+        }
+        
         $input = new StringInput((string) $input . ' --working-dir=.');
 
         $this->getIO()->writeError('<info>Run with <comment>' . $input->__toString() . '</comment></info>', true, IOInterface::VERBOSE);

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -2,6 +2,7 @@
 
 namespace Bamarni\Composer\Bin\Tests\Fixtures;
 
+use Composer\Composer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,12 +28,11 @@ class MyTestCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        // make sure the proxy command didn't instantiate Composer
-        $this->assert->assertNull($this->getComposer(false));
-        $this->assert->assertNull($this->getApplication()->getComposer(false));
-
-        // put a dummy composer.json to be able to create Composer
-        file_put_contents(getcwd().'/composer.json', '{}');
+        $this->assert->assertInstanceOf(
+            Composer::class,
+            $this->getComposer(),
+            "Some plugins may require access to composer file e.g. Symfony Flex"
+        );
 
         $factory = Factory::create(new NullIO());
         $config = $factory->getConfig();

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -2,7 +2,6 @@
 
 namespace Bamarni\Composer\Bin\Tests\Fixtures;
 
-use Composer\Composer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,7 +28,7 @@ class MyTestCommand extends BaseCommand
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->assert->assertInstanceOf(
-            Composer::class,
+            '\Composer\Composer',
             $this->getComposer(),
             "Some plugins may require access to composer file e.g. Symfony Flex"
         );


### PR DESCRIPTION
The source of issue in #39 appears to be custom [`RequireCommand` in Symfony Flex.](https://github.com/symfony/flex/blob/master/src/Command/RequireCommand.php#L45)

More specifically:

```php
$this->getComposer();
```

Making sure that composer file exists fixes the issue.

Should I add tests and document it or do you see some better solution?

I have tried disabling plugins in command that `BinCommand` is running, but I think plugins are already loaded at that time, so it has no effect.