### PR TITLE
add bin command for composer install --no-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ For convenience, you can add the following script in your `composer.json` :
 ```json
 {
     "scripts": {
+        "bin": "echo 'bin not installed'",
         "post-install-cmd": ["@composer bin all install --ansi"],
         "post-update-cmd": ["@composer bin all update --ansi"]
     }


### PR DESCRIPTION
If `composer require --dev bamarni/composer-bin-plugin` was used to install this Plugin.
and the Auto-installation scripts are installed in the `composer.json`, then the `composer install --no-dev` throws n error.

With this change in the `composer.json` the error goes away