### PR TITLE
Add support for composer-plugin-api ^2 and implement PlginInterface methods from ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,4 +25,18 @@ class Plugin implements PluginInterface, Capable
             'Composer\Plugin\Capability\CommandProvider' => 'Bamarni\Composer\Bin\CommandProvider',
         ];
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
Hi Bilal,

This PR adds support for Composer v2 for this plugin! composer/composer#8726 and has more information on changes. 

Composer version 2 has `composer-plugin-api` version 2. This commit updates the version constraint to `^1 || ^2` so we can support both composer versions.

See [What's new in Composer 2](https://php.watch/articles/composer-2) and [UPGRADE-2.0](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors) for more changes in API. Empty methods `\Bamarni\Composer\Bin\Plugin::deactivate()` and `\Bamarni\Composer\Bin\Plugin::uninstall()` are added to make it compatible both versions.

Travis will report that this builds fails. It is because the `composer/composer` package is not pinned to a version constraint. Even without these changes, [builds fail](https://travis-ci.com/github/Ayesh/composer-bin-plugin/builds/160050618). 

Thank you.