### PR TITLE
Upgrade supported PHP versions to PHP ^5.6, ^7.0, and ^8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - "$HOME/.composer/cache"
 
 php:
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
@@ -18,7 +16,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: '5.4'
+    - php: '5.6'
       env: COMPOSER_FLAGS='--prefer-lowest'
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "composer-plugin-api": "^1.0"
     },
     "require-dev": {
-        "composer/composer": "dev-master",
+        "composer/composer": "^1.0 || ^2.0",
         "symfony/console": "^2.5 || ^3.0 || ^4.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "composer-plugin-api": "^1.0"
     },
     "require-dev": {

--- a/src/BinCommand.php
+++ b/src/BinCommand.php
@@ -22,10 +22,10 @@ class BinCommand extends BaseCommand
         $this
             ->setName('bin')
             ->setDescription('Run a command inside a bin namespace')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('namespace', InputArgument::REQUIRED),
                 new InputArgument('args', InputArgument::REQUIRED | InputArgument::IS_ARRAY),
-            ))
+            ])
             ->ignoreValidationErrors()
         ;
     }

--- a/src/CommandProvider.php
+++ b/src/CommandProvider.php
@@ -11,6 +11,6 @@ class CommandProvider implements CommandProviderCapability
      */
     public function getCommands()
     {
-        return array(new BinCommand);
+        return [new BinCommand];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,11 +12,11 @@ final class Config
     {
         $extra = $composer->getPackage()->getExtra();
         $this->config = array_merge(
-            array(
+            [
                 'bin-links' => true,
                 'target-directory' => 'vendor-bin',
-            ),
-            isset($extra['bamarni-bin']) ? $extra['bamarni-bin'] : array()
+            ],
+            isset($extra['bamarni-bin']) ? $extra['bamarni-bin'] : []
         );
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,8 +21,8 @@ class Plugin implements PluginInterface, Capable
      */
     public function getCapabilities()
     {
-        return array(
+        return [
             'Composer\Plugin\Capability\CommandProvider' => 'Bamarni\Composer\Bin\CommandProvider',
-        );
+        ];
     }
 }

--- a/tests/BinCommandTest.php
+++ b/tests/BinCommandTest.php
@@ -23,16 +23,16 @@ class BinCommandTest extends \PHPUnit_Framework_TestCase
         file_put_contents($this->rootDir.'/composer.json', '{}');
 
         $this->application = new Application();
-        $this->application->addCommands(array(
+        $this->application->addCommands([
             new BinCommand(),
             $this->myTestCommand = new MyTestCommand($this),
-        ));
+        ]);
     }
 
     public function tearDown()
     {
         putenv('COMPOSER_BIN_DIR');
-        $this->myTestCommand->data = array();
+        $this->myTestCommand->data = [];
     }
 
     /**
@@ -53,10 +53,10 @@ class BinCommandTest extends \PHPUnit_Framework_TestCase
 
     public static function namespaceProvider()
     {
-        return array(
-            array('bin mynamespace mytest'),
-            array('bin mynamespace mytest --myoption'),
-        );
+        return [
+            ['bin mynamespace mytest'],
+            ['bin mynamespace mytest --myoption'],
+        ];
     }
 
     public function testAllNamespaceWithoutAnyNamespace()
@@ -70,7 +70,7 @@ class BinCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testAllNamespaceCommand()
     {
-        $namespaces = array('mynamespace', 'yournamespace');
+        $namespaces = ['mynamespace', 'yournamespace'];
         foreach ($namespaces as $ns) {
             mkdir($this->rootDir.'/vendor-bin/'.$ns, 0777, true);
         }
@@ -92,11 +92,11 @@ class BinCommandTest extends \PHPUnit_Framework_TestCase
     public function testBinDirFromLocalConfig()
     {
         $binDir = 'bin';
-        $composer = array(
-            'config' => array(
+        $composer = [
+            'config' => [
                 'bin-dir' => $binDir
-            )
-        );
+            ]
+        ];
         file_put_contents($this->rootDir.'/composer.json', json_encode($composer));
 
         $input = new StringInput('bin theirspace mytest');

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -11,7 +11,7 @@ use Composer\IO\NullIO;
 
 class MyTestCommand extends BaseCommand
 {
-    public $data = array();
+    public $data = [];
 
     private $assert;
 
@@ -20,9 +20,9 @@ class MyTestCommand extends BaseCommand
         $this->assert = $assert;
 
         parent::__construct('mytest');
-        $this->setDefinition(array(
+        $this->setDefinition([
             new InputOption('myoption', null, InputOption::VALUE_NONE),
-        ));
+        ]);
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -36,11 +36,11 @@ class MyTestCommand extends BaseCommand
         $factory = Factory::create(new NullIO());
         $config = $factory->getConfig();
 
-        $this->data[] = array(
+        $this->data[] = [
             'bin-dir' => $config->get('bin-dir'),
             'cwd' => getcwd(),
             'vendor-dir' => $config->get('vendor-dir'),
-        );
+        ];
 
         $this->resetComposer();
         $this->getApplication()->resetComposer();


### PR DESCRIPTION
Related: #52

Let's upgrade to PHP 5.6 :) 
Please note that this patch is necessary for #52 to pass CI, so ideally this PR is merged first. Merging this will result in a merge-conflict for #52, but I can work on a another push that would [fix everything](https://travis-ci.com/github/Ayesh/composer-bin-plugin/builds/160676069). 