### PR TITLE
Fix deprecations from Symfony debug

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,14 +10,14 @@ use Composer\Plugin\Capable;
 class Plugin implements PluginInterface, Capable
 {
     /**
-     * {@inheritDoc}
+     * @return void
      */
-    public function activate(Composer $composer, IOInterface $io): void
+    public function activate(Composer $composer, IOInterface $io)
     {
     }
 
     /**
-     * {@inheritDoc}
+     * @return array
      */
     public function getCapabilities(): array
     {
@@ -27,14 +27,14 @@ class Plugin implements PluginInterface, Capable
     }
 
     /**
-     * {@inheritDoc}
+     * @return void
      */
     public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 
     /**
-     * {@inheritDoc}
+     * @return void
      */
     public function uninstall(Composer $composer, IOInterface $io): void
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,14 +12,14 @@ class Plugin implements PluginInterface, Capable
     /**
      * {@inheritDoc}
      */
-    public function activate(Composer $composer, IOInterface $io)
+    public function activate(Composer $composer, IOInterface $io): void
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getCapabilities()
+    public function getCapabilities(): array
     {
         return [
             'Composer\Plugin\Capability\CommandProvider' => 'Bamarni\Composer\Bin\CommandProvider',
@@ -29,14 +29,14 @@ class Plugin implements PluginInterface, Capable
     /**
      * {@inheritDoc}
      */
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,7 +19,7 @@ class Plugin implements PluginInterface, Capable
     /**
      * @return array
      */
-    public function getCapabilities(): array
+    public function getCapabilities()
     {
         return [
             'Composer\Plugin\Capability\CommandProvider' => 'Bamarni\Composer\Bin\CommandProvider',
@@ -29,14 +29,14 @@ class Plugin implements PluginInterface, Capable
     /**
      * @return void
      */
-    public function deactivate(Composer $composer, IOInterface $io): void
+    public function deactivate(Composer $composer, IOInterface $io)
     {
     }
 
     /**
      * @return void
      */
-    public function uninstall(Composer $composer, IOInterface $io): void
+    public function uninstall(Composer $composer, IOInterface $io)
     {
     }
 }


### PR DESCRIPTION
```
09:36:55 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::activate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message.
[
  "exception" => ErrorException {
    #message: "User Deprecated: Method "Composer\Plugin\PluginInterface::activate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message."
    #code: 0
    #file: "./vendor/symfony/error-handler/DebugClassLoader.php"
    #line: 325
    #severity: E_USER_DEPRECATED
    trace: {
      ./vendor/symfony/error-handler/DebugClassLoader.php:325 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:295 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:486 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:103 { …}
      ./vendor/composer/composer/src/Composer/Factory.php:439 { …}
      ./src/Core/Framework/Plugin/Composer/Factory.php:19 {
        Shopware\Core\Framework\Plugin\Composer\Factory::createComposer(string $composerJsonDir, IOInterface $composerIO = null): Composer^
        › return (new ComposerFactory())->createComposer(
        ›     $composerIO,
        ›     $composerJsonDir . '/composer.json',
      }
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:113 { …}
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:41 { …}
      ./src/Core/Framework/Plugin/PluginService.php:85 { …}
      ./src/Core/Framework/Plugin/Command/PluginRefreshCommand.php:56 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:180 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:146 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./vendor/symfony/console/Application.php:1033 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:96 { …}
      ./vendor/symfony/console/Application.php:299 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:82 { …}
      ./vendor/symfony/console/Application.php:171 { …}
      ./bin/shopware:61 { …}
    }
  }
]
09:36:55 INFO      [php] User Deprecated: Method "Composer\Plugin\Capable::getCapabilities()" might add "array" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message.
[
  "exception" => ErrorException {
    #message: "User Deprecated: Method "Composer\Plugin\Capable::getCapabilities()" might add "array" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message."
    #code: 0
    #file: "./vendor/symfony/error-handler/DebugClassLoader.php"
    #line: 325
    #severity: E_USER_DEPRECATED
    trace: {
      ./vendor/symfony/error-handler/DebugClassLoader.php:325 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:295 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:486 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:103 { …}
      ./vendor/composer/composer/src/Composer/Factory.php:439 { …}
      ./src/Core/Framework/Plugin/Composer/Factory.php:19 {
        Shopware\Core\Framework\Plugin\Composer\Factory::createComposer(string $composerJsonDir, IOInterface $composerIO = null): Composer^
        › return (new ComposerFactory())->createComposer(
        ›     $composerIO,
        ›     $composerJsonDir . '/composer.json',
      }
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:113 { …}
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:41 { …}
      ./src/Core/Framework/Plugin/PluginService.php:85 { …}
      ./src/Core/Framework/Plugin/Command/PluginRefreshCommand.php:56 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:180 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:146 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./vendor/symfony/console/Application.php:1033 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:96 { …}
      ./vendor/symfony/console/Application.php:299 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:82 { …}
      ./vendor/symfony/console/Application.php:171 { …}
      ./bin/shopware:61 { …}
    }
  }
]
09:36:55 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::deactivate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message.
[
  "exception" => ErrorException {
    #message: "User Deprecated: Method "Composer\Plugin\PluginInterface::deactivate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message."
    #code: 0
    #file: "./vendor/symfony/error-handler/DebugClassLoader.php"
    #line: 325
    #severity: E_USER_DEPRECATED
    trace: {
      ./vendor/symfony/error-handler/DebugClassLoader.php:325 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:295 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:486 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:103 { …}
      ./vendor/composer/composer/src/Composer/Factory.php:439 { …}
      ./src/Core/Framework/Plugin/Composer/Factory.php:19 {
        Shopware\Core\Framework\Plugin\Composer\Factory::createComposer(string $composerJsonDir, IOInterface $composerIO = null): Composer^
        › return (new ComposerFactory())->createComposer(
        ›     $composerIO,
        ›     $composerJsonDir . '/composer.json',
      }
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:113 { …}
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:41 { …}
      ./src/Core/Framework/Plugin/PluginService.php:85 { …}
      ./src/Core/Framework/Plugin/Command/PluginRefreshCommand.php:56 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:180 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:146 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./vendor/symfony/console/Application.php:1033 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:96 { …}
      ./vendor/symfony/console/Application.php:299 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:82 { …}
      ./vendor/symfony/console/Application.php:171 { …}
      ./bin/shopware:61 { …}
    }
  }
]
09:36:55 INFO      [php] User Deprecated: Method "Composer\Plugin\PluginInterface::uninstall()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message.
[
  "exception" => ErrorException {
    #message: "User Deprecated: Method "Composer\Plugin\PluginInterface::uninstall()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bamarni\Composer\Bin\Plugin" now to avoid errors or add an explicit @return annotation to suppress this message."
    #code: 0
    #file: "./vendor/symfony/error-handler/DebugClassLoader.php"
    #line: 325
    #severity: E_USER_DEPRECATED
    trace: {
      ./vendor/symfony/error-handler/DebugClassLoader.php:325 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:295 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:486 { …}
      ./vendor/composer/composer/src/Composer/Plugin/PluginManager.php:103 { …}
      ./vendor/composer/composer/src/Composer/Factory.php:439 { …}
      ./src/Core/Framework/Plugin/Composer/Factory.php:19 {
        Shopware\Core\Framework\Plugin\Composer\Factory::createComposer(string $composerJsonDir, IOInterface $composerIO = null): Composer^
        › return (new ComposerFactory())->createComposer(
        ›     $composerIO,
        ›     $composerJsonDir . '/composer.json',
      }
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:113 { …}
      ./src/Core/Framework/Plugin/Util/PluginFinder.php:41 { …}
      ./src/Core/Framework/Plugin/PluginService.php:85 { …}
      ./src/Core/Framework/Plugin/Command/PluginRefreshCommand.php:56 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:180 { …}
      ./src/Core/Maintenance/System/Command/SystemInstallCommand.php:146 { …}
      ./vendor/symfony/console/Command/Command.php:298 { …}
      ./vendor/symfony/console/Application.php:1033 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:96 { …}
      ./vendor/symfony/console/Application.php:299 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:82 { …}
      ./vendor/symfony/console/Application.php:171 { …}
      ./bin/shopware:61 { …}
    }
  }
]
```