### PR TITLE
add forward mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     1. [Auto-installation](#auto-installation)
     1. [Disable links](#disable-links)
     1. [Change directory](#change-directory)
+    1. [Forward mode](#forward-mode)
     1. [Reduce clutter](#reduce-clutter)
 1. [Related plugins](#related-plugins)
 
@@ -162,7 +163,6 @@ For convenience, you can add the following script in your `composer.json` :
 
 This makes sure all your bins are installed during `composer install` and updated during `composer update`.
 
-
 ### Disable links
 
 By default, binaries of the sub namespaces are linked to the root one like described in [example](#example). If you
@@ -178,7 +178,6 @@ wish to disable that behaviour, you can do so by adding a little setting in the 
 }
 ```
 
-
 ### Change directory
 
 By default, the packages are looked for in the `vendor-bin` directory. The location can be changed using `target-directory` value in the extra config:
@@ -192,6 +191,23 @@ By default, the packages are looked for in the `vendor-bin` directory. The locat
     }
 }
 ```
+
+### Forward mode
+
+There is a `forward mode` which is disabled by default. This can be activated by using the `forward-command` value in the extra config.
+
+```json
+{
+    "extra": {
+        "bamarni-bin": {
+            "forward-command": true
+        }
+    }
+}
+```
+
+If this mode is activated, all your `composer install` and `composer update` commands are forwared to all bin directories.
+This is an replacement for the tasks shown in section [Auto-installation](#auto-installation).
 
 ### Reduce clutter
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,6 +15,7 @@ final class Config
             [
                 'bin-links' => true,
                 'target-directory' => 'vendor-bin',
+                'forward-command' => false,
             ],
             isset($extra['bamarni-bin']) ? $extra['bamarni-bin'] : []
         );
@@ -34,5 +35,13 @@ final class Config
     public function getTargetDirectory()
     {
         return $this->config['target-directory'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCommandForwarded()
+    {
+        return $this->config['forward-command'];
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,21 +3,40 @@
 namespace Bamarni\Composer\Bin;
 
 use Composer\Composer;
+use Composer\Console\Application;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Plugin\CommandEvent;
+use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\Capable;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 
-class Plugin implements PluginInterface, Capable
+class Plugin implements PluginInterface, Capable, EventSubscriberInterface
 {
+    /**
+     * @var Composer
+     */
+    protected $composer;
+
+    /**
+     * @var IOInterface
+     */
+    protected $io;
+
     /**
      * @return void
      */
     public function activate(Composer $composer, IOInterface $io)
     {
+        $this->composer = $composer;
+        $this->io = $io;
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getCapabilities()
     {
@@ -38,5 +57,74 @@ class Plugin implements PluginInterface, Capable
      */
     public function uninstall(Composer $composer, IOInterface $io)
     {
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            PluginEvents::COMMAND => 'onCommandEvent',
+        ];
+    }
+
+    /**
+     * @param CommandEvent $event
+     * @return bool
+     */
+    public function onCommandEvent(CommandEvent $event)
+    {
+        $config = new Config($this->composer);
+
+        if ($config->isCommandForwarded()) {
+            switch ($event->getCommandName()) {
+                case 'update':
+                case 'install':
+                    return $this->onCommandEventInstallUpdate($event);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param CommandEvent $event
+     * @return bool
+     */
+    protected function onCommandEventInstallUpdate(CommandEvent $event)
+    {
+        $command = new BinCommand();
+        $command->setComposer($this->composer);
+        $command->setApplication(new Application());
+
+        $arguments = [
+            'command' => $command->getName(),
+            'namespace' => 'all',
+            'args' => [],
+        ];
+
+        foreach (array_filter($event->getInput()->getArguments()) as $argument) {
+            $arguments['args'][] = $argument;
+        }
+
+        foreach (array_keys(array_filter($event->getInput()->getOptions())) as $option) {
+            $arguments['args'][] = '--' . $option;
+        }
+
+        $definition = new InputDefinition();
+        $definition->addArgument(new InputArgument('command', InputArgument::REQUIRED));
+        $definition->addArguments($command->getDefinition()->getArguments());
+        $definition->addOptions($command->getDefinition()->getOptions());
+
+        $input = new ArrayInput($arguments, $definition);
+
+        try {
+            $returnCode = $command->run($input, $event->getOutput());
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return $returnCode === 0;
     }
 }


### PR DESCRIPTION
This PR tries to add a forward mode (you may have a better name).

If this mode is activated via config, an `composer install` and an `composer update` call is forwarded to all namespaced bin directories with all parameters. Setting up `post-install-cmd` or `post-update-cmd` in composer.json is not required to update namespaced bin directories.

This is related to #61, #65 and #66 