### PR TITLE
Rename plugin log prefix

### DIFF
--- a/e2e/scenario1/expected.txt
+++ b/e2e/scenario1/expected.txt
@@ -1,8 +1,8 @@
-[bamarni-bin-plugin] Current working directory: /path/to/project/e2e/scenario1
-[bamarni-bin-plugin] Configuring bin directory to /path/to/project/e2e/scenario1/vendor/bin.
-[bamarni-bin-plugin] Checking namespace vendor-bin/ns1
-[bamarni-bin-plugin] Changed current directory to vendor-bin/ns1.
-[bamarni-bin-plugin] Running `@composer update --verbose --working-dir='.'`.
+[bamarni-bin] Current working directory: /path/to/project/e2e/scenario1
+[bamarni-bin] Configuring bin directory to /path/to/project/e2e/scenario1/vendor/bin.
+[bamarni-bin] Checking namespace vendor-bin/ns1
+[bamarni-bin] Changed current directory to vendor-bin/ns1.
+[bamarni-bin] Running `@composer update --verbose --working-dir='.'`.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds
@@ -13,10 +13,10 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-[bamarni-bin-plugin] Changed current directory to /path/to/project/e2e/scenario1.
-[bamarni-bin-plugin] Checking namespace vendor-bin/ns2
-[bamarni-bin-plugin] Changed current directory to vendor-bin/ns2.
-[bamarni-bin-plugin] Running `@composer update --verbose --working-dir='.'`.
+[bamarni-bin] Changed current directory to /path/to/project/e2e/scenario1.
+[bamarni-bin] Checking namespace vendor-bin/ns2
+[bamarni-bin] Changed current directory to vendor-bin/ns2.
+[bamarni-bin] Running `@composer update --verbose --working-dir='.'`.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds
@@ -27,4 +27,4 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-[bamarni-bin-plugin] Changed current directory to /path/to/project/e2e/scenario1.
+[bamarni-bin] Changed current directory to /path/to/project/e2e/scenario1.

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -34,6 +34,6 @@ final class Logger
             ? IOInterface::VERBOSE
             : IOInterface::NORMAL;
 
-        $this->io->writeError('[bamarni-bin-plugin] '.$message, true, $verbosity);
+        $this->io->writeError('[bamarni-bin] '.$message, true, $verbosity);
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -52,7 +52,7 @@ final class LoggerTest extends TestCase
         );
 
         $message = 'Hello world!';
-        $expected = '[bamarni-bin-plugin] Hello world!'.PHP_EOL;
+        $expected = '[bamarni-bin] Hello world!'.PHP_EOL;
 
         foreach ($notLoggedVerbosities as $verbosity) {
             yield [$verbosity, $message, ''];
@@ -92,7 +92,7 @@ final class LoggerTest extends TestCase
         );
 
         $message = 'Hello world!';
-        $expected = '[bamarni-bin-plugin] Hello world!'.PHP_EOL;
+        $expected = '[bamarni-bin] Hello world!'.PHP_EOL;
 
         foreach ($notLoggedVerbosities as $verbosity) {
             yield [$verbosity, $message, ''];


### PR DESCRIPTION
Since the config in `extra` is `bamarni-bin`, I think it's better to keep the prefix `[bamarni-bin]` instead of `[bamarni-bin-plugin]`.