### PR TITLE
Simplify workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,23 +31,10 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     tools: "composer"
 
-            -   name: "Configure global composer"
-                run: |
-                    composer global config repositories.bin path $PWD
-                    composer global config allow-plugins.bamarni/composer-bin-plugin true
-
             # It is not used in the CI and the PHP constraints may not match
             # the CI.
             -   name: "Remove PHP-CS-Fixer"
                 run: composer remove --dev --no-update php-cs-fixer/shim
-
-            -   name: "Install bin plugin globally (PR-only)"
-                if: github.event_name == 'pull_request'
-                run: composer global require bamarni/composer-bin-plugin:dev-${GITHUB_SHA}
-
-            -   name: "Install bin plugin globally (master-only)"
-                if: github.event_name != 'pull_request'
-                run: composer global require bamarni/composer-bin-plugin:dev-master
 
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"
@@ -79,35 +66,19 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     tools: "composer"
 
-            -   name: "Configure global composer"
-                run: |
-                    composer global config repositories.bin path $PWD
-                    composer global config allow-plugins.bamarni/composer-bin-plugin true
-
             # It is not used in the CI and the PHP constraints may not match
             # the CI.
             -   name: "Remove PHP-CS-Fixer"
                 run: composer remove --dev --no-update php-cs-fixer/shim
 
-            -   name: "Install bin plugin globally (PR-only)"
-                if: github.event_name == 'pull_request'
-                run: composer global require bamarni/composer-bin-plugin:dev-${GITHUB_SHA}
-
             -   name: "Correct bin plugin version for e2e scenarios (PR-only)"
                 if: github.event_name == 'pull_request'
                 run: find e2e -maxdepth 1 -mindepth 1 -type d -exec bash -c "cd {} && composer require --dev bamarni/composer-bin-plugin:dev-${GITHUB_SHA} --no-update" \;
-
-            -   name: "Install bin plugin globally (master-only)"
-                if: github.event_name != 'pull_request'
-                run: composer global require bamarni/composer-bin-plugin:dev-master
 
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "highest"
-
-            -   name: "Validate composer.json"
-                run: "composer validate --strict --no-check-lock"
 
             -   name: "Run tests"
                 run: "vendor/bin/phpunit --group e2e"

--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ vendor-bin/**/composer.lock binary
 Before getting started, you need to install the plugin globally:
 
 ```bash
-$ composer global require --dev bamarni/composer-bin-plugin
-$ composer install  # now works
+$ composer install
 $ vendor/bin/phpunit # run the tests
+$ vendor/bin/php-cs-fixer # run PHP-CS-Fixer
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "composer/composer": "^2.0",
         "php-cs-fixer/shim": "^3.8",
         "phpstan/extension-installer": "^1.1",
+        "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/console": "^5.4.7 || ^6.0.7",
         "symfony/finder": "^5.4.7 || ^6.0.7",
         "symfony/process": "^5.4.7 || ^6.0.7"
@@ -42,13 +43,5 @@
         "psr-4": {
             "Bamarni\\Composer\\Bin\\Tests\\": "tests"
         }
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "@composer bin phpunit install"
-        ],
-        "post-update-cmd": [
-            "@post-install-cmd"
-        ]
     }
 }

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,5 +1,0 @@
-{
-    "require": {
-        "phpunit/phpunit": "^8.5 || ^9.5"
-    }
-}


### PR DESCRIPTION
With the introducing of end-to-end tests, I do not feel it is needed anymore to use the plugin on itself for PHPUnit. Since using the plugin on itself actually comes with a non-negligible cost:

- the CI is a bit more complex
- when developing on the project you need to install the plugin globally (not ideal)
