### PR TITLE
Fix forwarded command does not work on first install

### DIFF
--- a/e2e/scenario3/expected.txt
+++ b/e2e/scenario3/expected.txt
@@ -13,10 +13,15 @@ Package operations: 1 install, 0 updates, 0 removals
 Installs: bamarni/composer-bin-plugin:dev-hash
   - Installing bamarni/composer-bin-plugin (dev-hash): Symlinking from ../..
 Generating autoload files
-–––––––––––––––––––––
-[bamarni-bin] Calling onCommandEvent().
+> post-autoload-dump: Bamarni\Composer\Bin\Plugin->onPostAutoloadDump
+[bamarni-bin] Calling onPostAutoloadDump().
 [bamarni-bin] The command is being forwarded.
 [bamarni-bin] Original input: update --verbose.
+[bamarni-bin] Current working directory: /path/to/project/e2e/scenario3
+[bamarni-bin] Configuring bin directory to /path/to/project/e2e/scenario3/vendor/bin.
+[bamarni-bin] Checking namespace vendor-bin/ns1
+[bamarni-bin] Changed current directory to vendor-bin/ns1.
+[bamarni-bin] Running `@composer update --verbose --working-dir='.'`.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds
@@ -27,6 +32,26 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
+[bamarni-bin] Changed current directory to /path/to/project/e2e/scenario3.
+–––––––––––––––––––––
+[bamarni-bin] Calling onCommandEvent().
+[bamarni-bin] The command is being forwarded.
+[bamarni-bin] Original input: update --verbose.
+[bamarni-bin] Current working directory: /path/to/project/e2e/scenario3
+[bamarni-bin] Configuring bin directory to /path/to/project/e2e/scenario3/vendor/bin.
+[bamarni-bin] Checking namespace vendor-bin/ns1
+[bamarni-bin] Changed current directory to vendor-bin/ns1.
+[bamarni-bin] Running `@composer update --verbose --working-dir='.'`.
+Loading composer repositories with package information
+Updating dependencies
+Dependency resolution completed in 0.000 seconds
+Analyzed 90 packages to resolve dependencies
+Analyzed 90 rules to resolve dependencies
+Nothing to modify in lock file
+Installing dependencies from lock file (including require-dev)
+Nothing to install, update or remove
+Generating autoload files
+[bamarni-bin] Changed current directory to /path/to/project/e2e/scenario3.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds
@@ -37,3 +62,6 @@ Dependency resolution completed in 0.000 seconds
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
+> post-autoload-dump: Bamarni\Composer\Bin\Plugin->onPostAutoloadDump
+[bamarni-bin] Calling onPostAutoloadDump().
+[bamarni-bin] Command already forwarded within the process: skipping.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -115,8 +115,7 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
         string $commandName,
         InputInterface $input,
         OutputInterface $output
-    ): bool
-    {
+    ): bool {
         $config = Config::fromComposer($this->composer);
 
         if ($config->isCommandForwarded()
@@ -131,8 +130,7 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
     protected function onForwardedCommand(
         InputInterface $input,
         OutputInterface $output
-    ): bool
-    {
+    ): bool {
         if ($this->forwarded) {
             $this->logger->logDebug('Command already forwarded within the process: skipping.');
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,13 +8,18 @@ use Bamarni\Composer\Bin\CommandProvider as BamarniCommandProvider;
 use Composer\Composer;
 use Composer\Console\Application;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
 use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\Capable;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
 use Symfony\Component\Console\Command\Command;
 use Composer\Plugin\Capability\CommandProvider as ComposerPluginCommandProvider;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use function in_array;
 use function sprintf;
@@ -40,6 +45,8 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
      * @var Logger
      */
     private $logger;
+
+    private $forwarded = false;
 
     public function activate(Composer $composer, IOInterface $io): void
     {
@@ -67,53 +74,98 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
     {
         return [
             PluginEvents::COMMAND => 'onCommandEvent',
+            ScriptEvents::POST_AUTOLOAD_DUMP => 'onPostAutoloadDump',
         ];
+    }
+
+    public function onPostAutoloadDump(Event $event): void
+    {
+        $this->logger->logDebug('Calling onPostAutoloadDump().');
+
+        $eventIO = $event->getIO();
+
+        if (!($eventIO instanceof ConsoleIO)) {
+            return;
+        }
+
+        // This is a bit convoluted but Event does not expose the input unlike
+        // CommandEvent.
+        $publicIO = PublicIO::fromConsoleIO($eventIO);
+        $eventInput = $publicIO->getInput();
+
+        $this->onEvent(
+            $eventInput->getArgument('command'),
+            $eventInput,
+            $publicIO->getOutput()
+        );
     }
 
     public function onCommandEvent(CommandEvent $event): bool
     {
         $this->logger->logDebug('Calling onCommandEvent().');
 
+        return $this->onEvent(
+            $event->getCommandName(),
+            $event->getInput(),
+            $event->getOutput()
+        );
+    }
+
+    private function onEvent(
+        string $commandName,
+        InputInterface $input,
+        OutputInterface $output
+    ): bool
+    {
         $config = Config::fromComposer($this->composer);
 
         if ($config->isCommandForwarded()
-            && in_array($event->getCommandName(), self::FORWARDED_COMMANDS, true)
+            && in_array($commandName, self::FORWARDED_COMMANDS, true)
         ) {
-            return $this->onForwardedCommand($event);
+            return $this->onForwardedCommand($input, $output);
         }
 
         return true;
     }
 
-    protected function onForwardedCommand(CommandEvent $event): bool
+    protected function onForwardedCommand(
+        InputInterface $input,
+        OutputInterface $output
+    ): bool
     {
-        $this->logger->logDebug('The command is being forwarded.');
+        if ($this->forwarded) {
+            $this->logger->logDebug('Command already forwarded within the process: skipping.');
+
+            return true;
+        }
+
+        $this->forwarded = true;
+
+        $this->logger->logStandard('The command is being forwarded.');
         $this->logger->logDebug(
             sprintf(
                 'Original input: <comment>%s</comment>.',
-                $event->getInput()
+                $input
             )
         );
 
         // Note that the input & output of $io should be the same as the event
         // input & output.
         $io = $this->io;
-        $logger = new Logger($io);
 
         $application = new Application();
 
-        $command = new BinCommand($logger);
+        $command = new BinCommand();
         $command->setComposer($this->composer);
         $command->setApplication($application);
+        $command->setIO($io);
 
-        $forwardedCommandInput = BinInputFactory::createForwardedCommandInput(
-            $event->getInput()
-        );
+        $forwardedCommandInput = BinInputFactory::createForwardedCommandInput($input);
 
         try {
             return Command::SUCCESS === $command->run(
                 $forwardedCommandInput,
-                $event->getOutput()
+                $output
             );
         } catch (Throwable $throwable) {
             return false;

--- a/src/PublicIO.php
+++ b/src/PublicIO.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bamarni\Composer\Bin;
+
+use Composer\IO\ConsoleIO;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PublicIO extends ConsoleIO
+{
+    public static function fromConsoleIO(ConsoleIO $io): self
+    {
+        return new self(
+            $io->input,
+            $io->output,
+            $io->helperSet
+        );
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->input;
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+}

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -145,6 +145,11 @@ TXT
             'Installing bamarni/composer-bin-plugin (dev-hash): Symlinking from ../..',
             $normalizedContent
         );
+        $normalizedContent = preg_replace(
+            '/Dependency resolution completed in \d\.\d{3} seconds/',
+            'Dependency resolution completed in 0.000 seconds',
+            $normalizedContent
+        );
 
         return $normalizedContent;
     }


### PR DESCRIPTION
Closes #72

The issue was that `PluginEvents::COMMAND` is not triggered at all on the first install. The trick done here is to hook on the post dump autoload instead. This requires a few hack:

- extend `ConsoleIO` to expose the input & output
- ensure we are not forwarding the command twice

But I think overall this delivers a better user experience.