### PR TITLE
Fix logging when forwarding the command

### DIFF
--- a/e2e/scenario3/expected.txt
+++ b/e2e/scenario3/expected.txt
@@ -17,6 +17,11 @@ Generating autoload files
 [bamarni-bin] Calling onCommandEvent().
 [bamarni-bin] The command is being forwarded.
 [bamarni-bin] Original input: update --verbose.
+[bamarni-bin] Current working directory: /path/to/project/e2e/scenario3
+[bamarni-bin] Configuring bin directory to /path/to/project/e2e/scenario3/vendor/bin.
+[bamarni-bin] Checking namespace vendor-bin/ns1
+[bamarni-bin] Changed current directory to vendor-bin/ns1.
+[bamarni-bin] Running `@composer update --verbose --working-dir='.'`.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds
@@ -27,6 +32,7 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
+[bamarni-bin] Changed current directory to /path/to/project/e2e/scenario3.
 Loading composer repositories with package information
 Updating dependencies
 Dependency resolution completed in 0.000 seconds

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -98,13 +98,11 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
         // Note that the input & output of $io should be the same as the event
         // input & output.
         $io = $this->io;
-        $logger = new Logger($io);
 
-        $application = new Application();
-
-        $command = new BinCommand($logger);
+        $command = new BinCommand();
         $command->setComposer($this->composer);
-        $command->setApplication($application);
+        $command->setIO($io);
+        $command->setApplication(new Application());
 
         $forwardedCommandInput = BinInputFactory::createForwardedCommandInput(
             $event->getInput()


### PR DESCRIPTION
Although the logger was correctly configured, when initializing the command the IO was not configured properly and as a result `getIO()` resulted in a `NullIO`, which reconfigured the logger...