### PR TITLE
Use requireComposer() when possible

### DIFF
--- a/src/Command/BinCommand.php
+++ b/src/Command/BinCommand.php
@@ -25,6 +25,7 @@ use function file_exists;
 use function file_put_contents;
 use function getcwd;
 use function glob;
+use function method_exists;
 use function min;
 use function mkdir;
 use function putenv;
@@ -95,7 +96,11 @@ class BinCommand extends BaseCommand
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         // Switch to requireComposer() once Composer 2.3 is set as the minimum
-        $config = Config::fromComposer($this->getComposer());
+        $composer = method_exists($this, 'requireComposer')
+            ? $this->requireComposer()
+            : $this->getComposer();
+
+        $config = Config::fromComposer($composer);
         $currentWorkingDir = getcwd();
 
         $this->logger->logDebug(


### PR DESCRIPTION
Since `getComposer()` is deprecated, let's use its recommended alternative when possible.