### PR TITLE
Fix exit code returned when executing all bin namespaces

### DIFF
--- a/src/Command/BinCommand.php
+++ b/src/Command/BinCommand.php
@@ -174,7 +174,7 @@ class BinCommand extends BaseCommand
             );
         }
 
-        return min($exitCode, self::FAILURE);
+        return min($exitCode, 255);
     }
 
     private function executeInNamespace(


### PR DESCRIPTION
If more than one bin namespace return a non-zero exit code or one returns an exit code member of ]1;255], then this exit code should be returned, instead of currently `1`.

The issue has been introduced in f0b48b5b4fbc13a49bc0d462ec518e27c1ed4ba8 see https://github.com/bamarni/composer-bin-plugin/commit/f0b48b5b4fbc13a49bc0d462ec518e27c1ed4ba8#r78753056.