### PR TITLE
Correct the Symfony constraints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,9 +21,11 @@ jobs:
                     - "8.0"
                     - "8.1"
                 tools: [ "composer" ]
+                dependency-versions: [ "highest" ]
                 include:
                     - php: "7.2"
                       tools: "composer:v2.0"
+                      dependency-versions: "lowest"
 
         steps:
             -   name: "Check out repository code"
@@ -38,7 +40,7 @@ jobs:
             -   name: "Install Composer dependencies"
                 uses: "ramsey/composer-install@v2"
                 with:
-                    dependency-versions: "highest"
+                    dependency-versions: "${{ matrix.dependency-versions }}"
 
             -   name: "Validate composer.json"
                 run: "composer validate --strict --no-check-lock"

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/phpunit": "^8.5 || ^9.5",
-        "symfony/console": "^5.4.7 || ^6.0.7",
-        "symfony/finder": "^5.4.7 || ^6.0.7",
-        "symfony/process": "^5.4.7 || ^6.0.7"
+        "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/BinCommand.php
+++ b/src/Command/BinCommand.php
@@ -160,10 +160,10 @@ class BinCommand extends BaseCommand
 
             // Is a valid scenario: the user may not have set up any bin
             // namespace yet
-            return self::SUCCESS;
+            return 0;
         }
 
-        $exitCode = self::SUCCESS;
+        $exitCode = 0;
 
         foreach ($namespaces as $namespace) {
             $exitCode += $this->executeInNamespace(
@@ -200,7 +200,7 @@ class BinCommand extends BaseCommand
                 )
             );
 
-            return self::FAILURE;
+            return 1;
         }
 
         // Use a new application: this avoids a variety of issues:

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -7,6 +7,7 @@ namespace Bamarni\Composer\Bin\Tests\Config;
 use Bamarni\Composer\Bin\Config\Config;
 use Bamarni\Composer\Bin\Config\InvalidBamarniComposerExtraConfig;
 use PHPUnit\Framework\TestCase;
+use function function_exists;
 
 /**
  * @covers \Bamarni\Composer\Bin\Config\Config
@@ -118,7 +119,9 @@ final class ConfigTest extends TestCase
                     Config::TARGET_DIRECTORY => false,
                 ],
             ],
-            'Expected setting "bamarni-bin.target-directory" to be a string. Got "bool".',
+            function_exists('get_debug_type')
+                ? 'Expected setting "bamarni-bin.target-directory" to be a string. Got "bool".'
+                : 'Expected setting "bamarni-bin.target-directory" to be a string. Got "boolean".',
         ];
 
         yield 'non bool forward command' => [

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -57,6 +57,6 @@ class MyTestCommand extends BaseCommand
         $this->resetComposer();
         $this->getApplication()->resetComposer();
 
-        return self::SUCCESS;
+        return 0;
     }
 }

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Composer\Command\BaseCommand;
 use Composer\Factory;
 use Composer\IO\NullIO;
+use function method_exists;
 
 class MyTestCommand extends BaseCommand
 {
@@ -39,7 +40,10 @@ class MyTestCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->composer = $this->tryComposer();
+        // Switch to tryComposer() once Composer 2.3 is set as the minimum
+        $this->composer = method_exists($this, 'tryComposer')
+            ? $this->tryComposer()
+            : $this->getComposer(false);
 
         $factory = Factory::create(new NullIO());
         $config = $factory->getConfig();


### PR DESCRIPTION
I am not sure why I bumped it to 5.4 minimum, from Composer itself it looks like the old versions can still be installed: https://github.com/composer/composer/blob/2.2/composer.json#L35