### PR TITLE
Fix the pipeline

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: "Unit Tests"
+name: "Tests"
 
 on:
     push:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PHPUNIT_BIN = vendor/bin/phpunit
 PHPUNIT = php -d zend.enable_gc=0 $(PHPUNIT_BIN)
 PHPUNIT_COVERAGE = XDEBUG_MODE=coverage $(PHPUNIT) --group default --coverage-xml=$(COVERAGE_DIR)/coverage-xml --log-junit=$(COVERAGE_DIR)/phpunit.junit.xml
 PHPSTAN_BIN = vendor/bin/phpstan
-PHPSTAN = $(PHPSTAN_BIN) analyse --level=5 src tests
+PHPSTAN = $(PHPSTAN_BIN) analyse --level=5 src tests 
 PHP_CS_FIXER_BIN = tools/php-cs-fixer
 PHP_CS_FIXER = $(PHP_CS_FIXER_BIN) fix --ansi --verbose --config=.php-cs-fixer.php
 COMPOSER_NORMALIZE_BIN=tools/composer-normalize

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PHPUNIT_BIN = vendor/bin/phpunit
 PHPUNIT = php -d zend.enable_gc=0 $(PHPUNIT_BIN)
 PHPUNIT_COVERAGE = XDEBUG_MODE=coverage $(PHPUNIT) --group default --coverage-xml=$(COVERAGE_DIR)/coverage-xml --log-junit=$(COVERAGE_DIR)/phpunit.junit.xml
 PHPSTAN_BIN = vendor/bin/phpstan
-PHPSTAN = $(PHPSTAN_BIN) analyse --level=5 src tests 
+PHPSTAN = $(PHPSTAN_BIN) analyse --level=5 src tests
 PHP_CS_FIXER_BIN = tools/php-cs-fixer
 PHP_CS_FIXER = $(PHP_CS_FIXER_BIN) fix --ansi --verbose --config=.php-cs-fixer.php
 COMPOSER_NORMALIZE_BIN=tools/composer-normalize

--- a/e2e/scenario0/expected.txt
+++ b/e2e/scenario0/expected.txt
@@ -6,7 +6,6 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Checking namespace vendor-bin/ns2
 Loading composer repositories with package information
 Updating dependencies
@@ -15,4 +14,3 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.

--- a/e2e/scenario1/expected.txt
+++ b/e2e/scenario1/expected.txt
@@ -12,7 +12,6 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Changed current directory to /path/to/project/e2e/scenario1.
 [bamarni-bin] Checking namespace vendor-bin/ns2
 [bamarni-bin] Changed current directory to vendor-bin/ns2.
@@ -26,5 +25,4 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Changed current directory to /path/to/project/e2e/scenario1.

--- a/e2e/scenario11/expected.txt
+++ b/e2e/scenario11/expected.txt
@@ -17,5 +17,3 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
-No security vulnerability advisories found

--- a/e2e/scenario3/expected.txt
+++ b/e2e/scenario3/expected.txt
@@ -28,9 +28,7 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Changed current directory to /path/to/project/e2e/scenario3.
-No security vulnerability advisories found
 –––––––––––––––––––––
 [bamarni-bin] Calling onCommandEvent().
 [bamarni-bin] The command is being forwarded.
@@ -47,7 +45,6 @@ Nothing to modify in lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Changed current directory to /path/to/project/e2e/scenario3.
 Loading composer repositories with package information
 Updating dependencies
@@ -60,4 +57,3 @@ Generating autoload files
 > post-autoload-dump: Bamarni\Composer\Bin\BamarniBinPlugin->onPostAutoloadDump
 [bamarni-bin] Calling onPostAutoloadDump().
 [bamarni-bin] Command already forwarded within the process: skipping.
-No security vulnerability advisories found

--- a/e2e/scenario8/expected.txt
+++ b/e2e/scenario8/expected.txt
@@ -28,6 +28,4 @@ Writing lock file
 Installing dependencies from lock file (including require-dev)
 Nothing to install, update or remove
 Generating autoload files
-No installed packages - skipping audit.
 [bamarni-bin] Changed current directory to /path/to/project/e2e/scenario8.
-No security vulnerability advisories found

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,10 @@
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <env name="COMPOSER_NO_AUDIT" value="1"/>
+    </php>
+
     <testsuites>
         <testsuite name="Composer Bin Plugin Test Suite">
             <directory>tests</directory>


### PR DESCRIPTION
Composer now skips the audit by default in the pipeline. To mimic this locally, we can simply set `COMPOSER_NO_AUDIT=1` in the PHPUnit config.