### PR TITLE
Fix endless recursion when `--working-dir` option precedes the subcommand (#172)

### DIFF
--- a/src/Input/BinInputFactory.php
+++ b/src/Input/BinInputFactory.php
@@ -75,8 +75,8 @@ final class BinInputFactory
             array_map(
                 'trim',
                 [
-                    $matches[1],
                     '--working-dir=.',
+                    $matches[1],
                     $matches[2] ?? '',
                     $matches[3] ?? '',
                 ]


### PR DESCRIPTION
`--working-dir` is a global option and may appear before the subcommand (e.g. install/update).
Reorder the forwarded input so the namespace `--working-dir=.` always comes first.