### PR TITLE
fix: Revert incorrect requirement bump

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
                 dependency-versions: [ "highest" ]
                 include:
                     - php: "7.2"
-                      tools: "composer:v2.6"
+                      tools: "composer:v2.2"
                       dependency-versions: "lowest"
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "composer/composer": "^2.6",
+        "composer/composer": "^2.2.26",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.8 || ^2.0",
         "phpstan/phpstan-phpunit": "^1.1 || ^2.0",

--- a/src/Command/BinCommand.php
+++ b/src/Command/BinCommand.php
@@ -26,6 +26,7 @@ use function file_exists;
 use function file_put_contents;
 use function getcwd;
 use function glob;
+use function method_exists;
 use function min;
 use function mkdir;
 use function putenv;
@@ -96,7 +97,11 @@ class BinCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $composer = $this->requireComposer();
+        // Switch to requireComposer() once Composer 2.3 is set as the minimum
+        // @phpstan-ignore function.alreadyNarrowedType
+        $composer = method_exists($this, 'requireComposer')
+            ? $this->requireComposer()
+            : $this->getComposer();
 
         $config = Config::fromComposer($composer);
         $currentWorkingDir = getcwd();

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -46,7 +46,6 @@ class MyTestCommand extends BaseCommand
         $this->composer = method_exists($this, 'tryComposer')
             ? $this->tryComposer()
             : $this->getComposer(false);
-        $this->composer = $this->tryComposer();
 
         $factory = Factory::create(new NullIO());
         $config = $factory->getConfig();

--- a/tests/Fixtures/MyTestCommand.php
+++ b/tests/Fixtures/MyTestCommand.php
@@ -12,6 +12,8 @@ use Composer\Command\BaseCommand;
 use Composer\Factory;
 use Composer\IO\NullIO;
 
+use function method_exists;
+
 class MyTestCommand extends BaseCommand
 {
     /**
@@ -39,6 +41,11 @@ class MyTestCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
+        // Switch to tryComposer() once Composer 2.3 is set as the minimum
+        // @phpstan-ignore function.alreadyNarrowedType
+        $this->composer = method_exists($this, 'tryComposer')
+            ? $this->tryComposer()
+            : $this->getComposer(false);
         $this->composer = $this->tryComposer();
 
         $factory = Factory::create(new NullIO());


### PR DESCRIPTION
I intended to bump the minimum required Composer version in #177, unfortunately I missed to adjust the actual constraint `composer-plugin-api` there, resulting in issues to users.

This PR restores support for older Composer versions.

Closes #182.